### PR TITLE
make it easy to set an nscd version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Requirements
 Attributes
 ----------
 * `default['nscd']['package']` - nscd package name, defaults to `nscd`. Other variants include: `unscd`, `gnscd`
+* `default['nscd']['version']` - nscd version, defaults to `nil`. If set to `nil`, the latest will be installed.
 
 The following attributes affect configuration of `/etc/nscd.conf`.
 * `default['nscd']['logfile']`. Specifies name of the file to which debug info should be written. Default `/var/log/nscd`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,7 @@
 
 # Possible values: nscd, unscd, gnscd
 default['nscd']['package'] = 'nscd'
+default['nscd']['version'] = nil
 
 # nscd.conf parameters
 default['nscd']['logfile'] = '/var/log/nscd'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,7 @@
 
 package 'nscd' do
   package_name node['nscd']['package']
+  version node['nscd']['version'] unless node['nscd']['version'].nil?
   not_if { platform?('smartos') }
 end
 


### PR DESCRIPTION
Locking down the NSCD version is key in fixing GLIBC dependency issues on Debian [family] hosts.