### PR TITLE
Fix template-service order; Bring up-to-date for testing

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,9 +6,12 @@ platforms:
   - name: ubuntu-12.04
     run_list:
       - recipe[apt::default]
-  - name: centos-6.4
+#  - name: centos-6.4
 
 suites:
   - name: default
     run_list:
       - recipe[nscd::default]
+    attributes:
+      nscd:
+        server_user: "root"

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,7 +6,7 @@ platforms:
   - name: ubuntu-12.04
     run_list:
       - recipe[apt::default]
-#  - name: centos-6.4
+  - name: centos-6.6
 
 suites:
   - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,4 +14,4 @@ suites:
       - recipe[nscd::default]
     attributes:
       nscd:
-        server_user: "root"
+        server_user: "nobody"

--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,3 @@
-#site 'https://supermarket.chef.io'
-
 source 'https://supermarket.chef.io'
 metadata
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,6 @@
-site 'https://supermarket.chef.io'
+#site 'https://supermarket.chef.io'
+
+source 'https://supermarket.chef.io'
 metadata
 
 group :integration do

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,11 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf',  '~> 2.0'
-gem 'chefspec',   '~> 3.0'
+gem 'berkshelf',  '~> 3.0'
+gem 'chefspec',   '~> 4.0'
 gem 'foodcritic', '~> 3.0'
-gem 'rubocop',    '~> 0.18'
+gem 'rubocop',    '~> 0.30'
 
 group :integration do
-  gem 'test-kitchen',    '~> 1.1'
-  gem 'kitchen-vagrant', '~> 0.14'
+  gem 'test-kitchen',    '~> 1.3'
+  gem 'kitchen-vagrant', '~> 0.16'
 end

--- a/TESTING.md
+++ b/TESTING.md
@@ -32,7 +32,7 @@ Development
 
 2. Install the dependencies using bundler:
 
-        $ bundle install
+        $ bundle install --path vendor/bundle
 
 3. Create a branch for your changes:
 
@@ -40,6 +40,8 @@ Development
 
 4. Make any changes
 5. Write tests to support those changes. It is highly recommended you write both unit and integration tests.
+1. Install the cookbooks and gems locally:
+    - `bundle exec berks vendor vendor/cookbook`
 6. Run the tests:
     - `bundle exec rspec`
     - `bundle exec foodcritic .`

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,7 +26,7 @@ template '/etc/nscd.conf' do
   source 'nscd.conf.erb'
   owner 'root'
   group 'root'
-  mode 00644
+  mode '0644'
   variables(
     :settings => node['nscd']
   )

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,6 +22,17 @@ package 'nscd' do
   not_if { platform?('smartos') }
 end
 
+template '/etc/nscd.conf' do
+  source 'nscd.conf.erb'
+  owner 'root'
+  group 'root'
+  mode 00644
+  variables(
+    :settings => node['nscd']
+  )
+  notifies :restart, 'service[nscd]'
+end
+
 service 'nscd' do
   service_name 'name-service-cache:default' if platform?('smartos')
   supports :restart => true, :status => true
@@ -33,15 +44,4 @@ end
     command "/usr/sbin/nscd -i #{cmd}"
     action  :nothing
   end
-end
-
-template '/etc/nscd.conf' do
-  source 'nscd.conf.erb'
-  owner 'root'
-  group 'root'
-  mode 00644
-  variables(
-    :settings => node['nscd']
-  )
-  notifies :restart, 'service[nscd]'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,18 +1,2 @@
-require 'berkshelf'
 require 'chefspec'
-
-Berkshelf.ui.mute do
-  Berkshelf::Berksfile.from_file('Berksfile').install(path: 'vendor/cookbooks')
-end
-
-RSpec.configure do |config|
-  config.color_enabled = true
-  config.tty = true
-  config.formatter = :documentation
-  config.treat_symbols_as_metadata_keys_with_true_values = true
-  config.filter_run :focus => true
-  config.run_all_when_everything_filtered = true
-  config.expect_with :rspec do |c|
-    c.syntax = :expect
-  end
-end
+require 'chefspec/berkshelf'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'nscd::default' do
-  let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
   it 'installs nscd' do
     expect(chef_run).to install_package('nscd')

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,6 +1,5 @@
 require 'serverspec'
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
+set :backend, :exec
 
 describe 'nscd::default' do
   it 'has the nscd service up and running' do


### PR DESCRIPTION
The default recipe has the template AFTER the service commands.  So if you push a bad config, it breaks and you have to manually remove the nscd.conf. The template before service pattern is what I'm used to as well.

The other tweaks are to correct README and to use later ChefDK tools for testing.
